### PR TITLE
Added LWRP for retrieving Rackspace Cloud Files. Updated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 Description
 ===========
-This cookbook provides LWRP's to interact with Rackspace Cloud APIs.
+This cookbook provides libraries, resources and providers to configure and manage Rackspace Cloud objects using the Rackspace Cloud API.
 
-Supports
-========
-* Rackspace Cloud DNS
-* Rackspace Cloud Load Balancers (Coming Soon)
-* Rackspace Cloud Database (Coming Soon)
-* Rackspace Cloud Block Storage (Coming Soon)
-* Rackspace Cloud Servers (Coming Soon)
+Currently supported resources:
 
-Usage
-=====
-### Data Bags
-It is highly encouraged that you use an encrypted data bag to provide your Rackspace Cloud username and API key. To do so, make a data bag called ```rackspace``` with an item called ```cloud``` that has at least the following:
+* Rackspace Cloud DNS ( rackspacecloud_record )
+* Rackspace Cloud Files ( rackspacecloud_file )
+
+Coming soon:
+
+* Rackspace Cloud Load Balancers
+* Rackspace Cloud Database
+* Rackspace Cloud Block Storage
+* Rackspace Cloud Servers
+
+Requirements
+============
+
+Requires Chef 0.7.10 or higher for Lightweight Resource and Provider support. Chef 0.8+ is recommended. While this cookbook can be used in chef-solo mode, to gain the most flexibility, we recommend using chef-client with a Chef Server.
+
+A Rackspace Cloud account is required. The username and API key are used to authenticate with Rackspace Cloud.
+
+Rackspace Credentials
+=====================
+
+In order to manage Rackspace Cloud components, authentication credentials need to be available to the node. There are a number of ways to handle this, such as node attributes or roles. We recommend storing these in a databag item (Chef 0.8+), and loading them in the recipe where the resources are needed. To do so, make a data bag called ```rackspace``` with an item called ```cloud``` that has at least the following:
 
 ```json
 {
@@ -23,11 +34,56 @@ It is highly encouraged that you use an encrypted data bag to provide your Racks
 }
 ```
 
-You may choose to provide your ```rackspace_auth_url``` and ```rackspace_auth_region``` in the data bag as well, but they can generally be safely provided as attributes.
+You may choose to provide your ```rackspace_auth_url``` and ```rackspace_auth_region``` in the data bag item as well, but they can generally be safely provided as attributes.
 
-LWRPs
-=====
-## rackspace_record:
+The values can be loaded in a recipe with:
+
+```ruby
+rackspace = data_bag_item("rackspace", "cloud")
+```
+
+And to access the values:
+
+```ruby
+rackspace['rackspace_username']
+rackspace['rackspace_api_key']
+```
+
+The data bag items can also be encrypted for extra security.
+
+Recipes
+=======
+
+default.rb
+----------
+
+The default recipe installs the ```fog``` RubyGem, which this cookbook requires in order to work with the Rackspace API. Make sure that the default recipe is in the node or role ```run_list``` before any resources from this cookbook are used.
+
+"run_list": [
+  "recipe[rackspacecloud]"
+]
+
+The ```gem_package``` is created as a Ruby Object and thus installed during the compile phase of the Chef run.
+
+Libraries
+=========
+
+The cookbook has several library modules which can be included where necessary:
+
+```ruby
+Opscode::Rackspace
+Opscode::Rackspace::DNS
+Opscode::Rackspace::Storage
+```
+
+Resources and Providers
+=======================
+
+This cookbook provides several resources and corresponding providers.
+
+rackspacecloud_record
+---------------------
+
 Provides add, modify, remove functionality for Rackspace Cloud DNS records. Example:
 
 Add an A record:
@@ -71,12 +127,34 @@ end
 * ```ttl```: The TTL for the record. Default is ```300```.
 * ```action```: ```:add```, ```:delete```, ```:update```. Default is ```:add```.
 
+rackspacecloud_file
+-------------------
+
+Retrieves files from Rackspace Cloud Files. Example:
+
+```ruby
+rackspacecloud_file "/usr/share/tomcat5/webapps/demo.war" do
+  directory "wars"
+  rackspace_username "foo"
+  rackspace_api_key "nnnnnnnnnnn"
+  action :create
+end
+```
+
+### Attributes:
+* ```directory```: The directory on Rackspace Cloud Files where the file can be found.
+* ```rackspace_username```: The Rackspace API username. Can be retrieved from data bag or node attributes.
+* ```rackspace_api_key```: The Rackspace API key. Can be retrieved from data bag or node attributes.
+* ```action```: ```:create``` or ```:create_if_missing```. Default is ```:create```.
+
 License and Author
 ==================
 
 Author:: Ryan Walker (<ryan.walker@rackspace.com>)
+Author:: Julian Dunn (<jdunn@opscode.com>)
 
 Copyright 2013, Rackspace Hosting 
+Copyright 2013, Opscode, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,4 +22,3 @@ default[:rackspacecloud][:rackspace_username] = nil
 default[:rackspacecloud][:rackspace_apikey] = nil
 default[:rackspacecloud][:rackspace_auth_url] = "identity.api.rackspacecloud.com"
 default[:rackspacecloud][:rackspace_auth_region] = "us"
-default[:rackspacecloud][:packages] = ["libxml2", "libxml2-dev", "libxslt1-dev"]

--- a/libraries/storage.rb
+++ b/libraries/storage.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: rackspace
+# Library:: storage
+# Author:: Julian C. Dunn (<jdunn@opscode.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Opscode
+  module Rackspace
+    module Storage
+
+      include Opscode::Rackspace
+
+      def storage
+
+        @@storage ||= Fog::Storage.new({
+        	:provider            => 'Rackspace',
+        	:rackspace_username  => new_resource.rackspace_username,
+        	:rackspace_api_key   => new_resource.rackspace_api_key,
+        	:rackspace_region    => new_resource.rackspace_region || :dfw,
+        	:rackspace_auth_url  => new_resource.rackspace_auth_url || Fog::Rackspace::US_AUTH_ENDPOINT
+        })
+
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          "Apache 2.0"
 description      "Provides LWRP's for managing Rackspace Cloud resources." 
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.1"
+
+depends "xml"

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -1,0 +1,72 @@
+#
+# Cookbook Name:: rackspace
+# Provider:: cloudfile
+# Author:: Julian C. Dunn (<jdunn@opscode.com>)
+#
+# Copyright 2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'tempfile'
+require 'chef/digester'
+
+include Opscode::Rackspace::Storage
+
+def whyrun_supported?
+  true
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::RackspacecloudFile.new(@new_resource.name)
+  @current_resource.filename(@new_resource.filename)
+
+  if ::File.exists?(@current_resource.filename)
+    @current_resource.exists = true
+    @current_resource.checksum = Chef::Digester.checksum_for_file(@current_resource.filename)
+  else
+    @current_resource.exists = false
+  end
+  @current_resource
+end
+
+action :create do
+
+  f = Tempfile.new('download')
+  directory = get_directory(new_resource.directory)
+  directory.files.get(::File.basename(new_resource.filename)) do |data, remaining, content_length|
+    f.syswrite data
+  end
+
+  new_resource.checksum = Chef::Digester.checksum_for_file(f.path)
+  if !current_resource.exists || (current_resource.checksum != new_resource.checksum)
+    converge_by("Moving new file with checksum to #{new_resource.filename}") do
+      FileUtils.mv(f.path, new_resource.filename)
+    end
+  else
+    f.unlink
+  end
+end
+
+action :create_if_missing do
+
+  if !current_resource.exists
+    action_create
+  end
+end
+
+private
+
+def get_directory(n)
+  storage.directories.get(n)
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,12 +17,7 @@
 # limitations under the License.
 #
 
-node[:rackspacecloud][:packages].each do |pkg|
-  r = package pkg do
-    action :nothing
-  end
-  r.run_action(:install)
-end
+include_recipe 'xml::ruby'
 
 chef_gem "fog" do
   version node[:rackspacecloud][:fog_version]

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: rackspace
+# Resource:: cloudfile
+# Author:: Julian C. Dunn (<jdunn@opscode.com>)
+#
+# Copyright 2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :create_if_missing
+
+default_action :create
+
+attribute :rackspace_username, :kind_of => String, :required => true
+attribute :rackspace_api_key, :kind_of => String, :required => true
+attribute :rackspace_region, :kind_of => Symbol, :default => :dfw
+attribute :rackspace_auth_url, :kind_of => String
+attribute :filename, :kind_of => String, :name_attribute => true
+attribute :directory, :kind_of => String, :required => true
+
+attr_accessor :exists
+attr_accessor :checksum


### PR DESCRIPTION
I'd also like to know what you think of my way of managing the Rackspace credentials. Rather than forcing the user (in the Opscode::Rackspace library) to use a specific data bag and data bag item name, how about just letting them pass it in as an attribute to the resource, as I've done?
