### PR TITLE
xml::ruby doesn't work on Windows

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'xml::ruby'
+include_recipe 'xml::ruby' unless platform_family?("windows")
 
 chef_gem "fog" do
   version node[:rackspacecloud][:fog_version]


### PR DESCRIPTION
It's not needed to get Fog on Windows boxes anyways.
