### PR TITLE
Added binmode attribute for rackspacecloud_file resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ rackspacecloud_file "/usr/share/tomcat5/webapps/demo.war" do
   directory "wars"
   rackspace_username "foo"
   rackspace_api_key "nnnnnnnnnnn"
+  binmode true
   action :create
 end
 ```
@@ -153,6 +154,7 @@ end
 * ```directory```: The directory on Rackspace Cloud Files where the file can be found.
 * ```rackspace_username```: The Rackspace API username. Can be retrieved from data bag or node attributes.
 * ```rackspace_api_key```: The Rackspace API key. Can be retrieved from data bag or node attributes.
+* ```binmode```: ```true``` or ```false```. Default is ```false```. Setting this to ```true``` will download the file in binary mode.
 * ```action```: ```:create``` or ```:create_if_missing```. Default is ```:create```.
 
 rackspacecloud_lbaas
@@ -184,6 +186,7 @@ License and Author
 
 Author:: Ryan Walker (<ryan.walker@rackspace.com>)
 Author:: Julian Dunn (<jdunn@opscode.com>)
+Author:: Michael Goetz (<mpgoetz@opscode.com>)
 Author:: Zack Feldstein (<zack.feldstein@rackspace.com>)
 
 

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -43,6 +43,11 @@ end
 action :create do
 
   f = Tempfile.new('download')
+
+  if new_resource.binmode
+    f.binmode
+  end
+
   directory = get_directory(new_resource.directory)
   directory.files.get(::File.basename(new_resource.filename)) do |data, remaining, content_length|
     f.syswrite data

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -28,6 +28,7 @@ attribute :rackspace_region, :kind_of => Symbol, :default => :dfw
 attribute :rackspace_auth_url, :kind_of => String
 attribute :filename, :kind_of => String, :name_attribute => true
 attribute :directory, :kind_of => String, :required => true
+attribute :binmode, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 attr_accessor :exists
 attr_accessor :checksum


### PR DESCRIPTION
This adds an optional attribute to the rackspacecloud_file resource that will let you specify whether to download the file in binmode instead of textmode, which is the default.
