### PR TITLE
changed symbols to strings to maintain consistency

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -24,7 +24,7 @@ default_action :create
 
 attribute :rackspace_username, :kind_of => String, :required => true
 attribute :rackspace_api_key, :kind_of => String, :required => true
-attribute :rackspace_region, :kind_of => Symbol, :default => :dfw
+attribute :rackspace_region, :kind_of => String, :default => :dfw
 attribute :rackspace_auth_url, :kind_of => String
 attribute :filename, :kind_of => String, :name_attribute => true
 attribute :directory, :kind_of => String, :required => true

--- a/resources/lbaas.rb
+++ b/resources/lbaas.rb
@@ -21,7 +21,7 @@ default_action :add_node
 
 attribute :rackspace_username, :kind_of => String, :required => true
 attribute :rackspace_api_key, :kind_of => String, :required => true
-attribute :rackspace_region, :kind_of => Symbol, :default => :dfw
+attribute :rackspace_region, :kind_of => String, :default => :dfw
 attribute :rackspace_auth_url, :kind_of => String
 attribute :load_balancer_id, :name_attribute => true,  :kind_of => String, :required => true
 attribute :node_address, :kind_of => String, :required => true

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -23,7 +23,7 @@ default_action :add
 
 attribute :rackspace_username, :kind_of => String, :required => true
 attribute :rackspace_api_key, :kind_of => String, :required => true
-attribute :rackspace_region, :kind_of => Symbol, :default => :dfw
+attribute :rackspace_region, :kind_of => String, :default => :dfw
 attribute :rackspace_auth_url, :kind_of => String
 attribute :name, :name_attribute => true, :kind_of => String, :required => true
 attribute :record, :kind_of => String, :required => true


### PR DESCRIPTION
Can we switch rackspace_region to a string to match the rest of the attributes? This is mostly so that it's easier to modify in the recipes that call this one by using a node_attribute.
