### PR TITLE
Remove legacy credential loading

### DIFF
--- a/libraries/rackspace.rb
+++ b/libraries/rackspace.rb
@@ -29,22 +29,6 @@ module Opscode
           Chef::Log.error("Missing gem 'fog'. Use the default rackspace recipe to install it first.")
         end
 
-	get_credentials
-     end
-
-     def get_credentials
-       begin
-         if Chef::DataBag.list.keys.include?("rackspace") && data_bag("rackspace").include?("cloud")
-           creds = Chef::EncryptedDataBagItem.load("rackspace", "cloud")
-         end
-       rescue
-         Chef::Log.info("No Rackspace Cloud databag found. Using attributes for credentials.")
-       end
- 
-       @apikey = creds['rackspace_api_key'] rescue node[:rackspacecloud][:rackspace_api_key]
-       @username = creds['rackspace_username'] rescue node[:rackspacecloud][:rackspace_username]
-       @auth_url = creds['rackspace_auth_url'] rescue node[:rackspacecloud][:rackspace_auth_url]
-       @region = creds['rackspace_auth_region'] rescue node[:rackspacecloud][:rackspace_auth_region]
      end
 
   end


### PR DESCRIPTION
Credentials should be loaded in the resource call, not through a databag specific for this cookbook. This functionality was added a long time ago, but the databag code was never removed.
