### PR TITLE
Check the etag/checksum before downloading

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver_plugin: vagrant
 driver_config:
-  require_chef_omnibus: 11.4.4
+  require_chef_omnibus: latest
 platforms:
 - name: ubuntu-12.04
   driver_config:
@@ -9,24 +9,33 @@ platforms:
     box_url: http://files.vagrantup.com/precise64.box
   run_list:
   - recipe[apt]
+  attributes:
+    apt:
+      compile_time_update: true
 - name: ubuntu-10.04
   driver_config:
     box: opscode-ubuntu-10.04
     box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_chef-11.2.0.box
   run_list:
   - recipe[apt]
+  attributes:
+    xml:
+      nokogiri:
+        use_system_libraries: false
+    apt:
+      compile_time_update: true
 - name: centos-6.3
   driver_config:
     box: opscode-centos-6.3
     box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box
   run_list:
-  - recipe[yum::epel]
+  - recipe[yum-epel]
 - name: centos-5.8
   driver_config:
     box: opscode-centos-5.8
     box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.8_chef-11.2.0.box
   run_list:
-  - recipe[yum::epel]
+  - recipe[yum-epel]
 suites:
 - name: default
   run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,7 @@ metadata
 group :integration do
   cookbook "apt"
   cookbook "build-essential"
-  cookbook "yum"
+  cookbook "yum-epel"
   cookbook "minitest-handler"
   cookbook "rackspacecloud_test", :path => "./test/cookbooks/rackspacecloud_test"
 end


### PR DESCRIPTION
When downloading we can check the etag that is the same as the checksum
before using bandwidth to download files.

The tests currently fail for 2 reasons. One is the outstanding Mocks missing for Rackspace Cloud Files in fog, and two, the most recent xml cookbook is broken due to nokogiri trying to compile with system libraries no matter what the attribute is set to.

I am working on the upstream XML cookbook fix.
