### PR TITLE
fix cloudfiles checksum

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -59,7 +59,7 @@ action :create do
     f.syswrite data
   end
 
-  new_resource.checksum = Chef::Digester.checksum_for_file(f.path)
+  new_resource.checksum = Chef::Digester.generate_md5_checksum_for_file(f.path)
   if !current_resource.exists || (current_resource.checksum != new_resource.checksum)
     converge_by("Moving new file with checksum to #{new_resource.filename}") do
       move_file(f.path, new_resource.filename)


### PR DESCRIPTION
rackspacecloud_files resource is currently using two different hash functions for the current file and new file so the compare is always different. 

This makes them the same so the compare works.