### PR TITLE
Better error messages, new TK suites

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,43 +1,24 @@
 ---
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: latest
+driver:
+  name: vagrant
+
 platforms:
-- name: ubuntu-12.04
-  driver_config:
-    box: ubuntu-12.04
-    box_url: http://files.vagrantup.com/precise64.box
-  run_list:
-  - recipe[apt]
-  attributes:
-    apt:
-      compile_time_update: true
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_chef-11.2.0.box
-  run_list:
-  - recipe[apt]
-  attributes:
-    xml:
-      nokogiri:
-        use_system_libraries: false
-    apt:
-      compile_time_update: true
-- name: centos-6.3
-  driver_config:
-    box: opscode-centos-6.3
-    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box
-  run_list:
-  - recipe[yum-epel]
-- name: centos-5.8
-  driver_config:
-    box: opscode-centos-5.8
-    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.8_chef-11.2.0.box
-  run_list:
-  - recipe[yum-epel]
+  - name: ubuntu-14.04
+    run_list:
+    - recipe[apt]
+  - name: ubuntu-12.04
+    run_list:
+    - recipe[apt]
+  - name: centos-6.7
+    run_list:
+    - recipe[yum]
+
+# default values: https://github.com/test-kitchen/test-kitchen/blob/master/lib/kitchen/provisioner/chef_base.rb#L183-L190
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: true
+
 suites:
-- name: default
-  run_list:
-#  - recipe[minitest-handler]
-  - recipe[rackspacecloud_test]
+  - name: default
+    run_list:
+      - recipe[rackspacecloud_test]

--- a/providers/lbaas.rb
+++ b/providers/lbaas.rb
@@ -69,8 +69,9 @@ def remove_node(node_id)
     lbaas.delete_node(new_resource.load_balancer_id, node_id)
   rescue Fog::Rackspace::LoadBalancers::NotFound
     Chef::Log.info "Node does not belong to specified load balancer ID"
-  rescue Fog::Rackspace::LoadBalancers::ServiceError => e
-    raise "An error occurred removing node from load balancer #{e}"
+  rescue Fog::Rackspace::LoadBalancers::ServiceError => err
+    Chef::Log.warn "An error occurred removing node from load balancer"
+    raise err # preserve unknown errors and pass them along
   else
     Chef::Log.info "Node has been removed from load balancer pool"
   end
@@ -80,8 +81,9 @@ def add_node
   begin
     #add the node
     create_response = lbaas.create_node(new_resource.load_balancer_id, new_resource.node_address, new_resource.port, new_resource.condition)
-  rescue Fog::Rackspace::LoadBalancers::ServiceError => e
-    raise "An error occured making the create node request: #{e}"
+  rescue Fog::Rackspace::LoadBalancers::ServiceError => err
+    Chef::Log.warn "An error occured making the create node request"
+    raise err # preserve unknown errors and pass them along
   end
   Chef::Log.info "Node successfully added to cloud loadbalancer"
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: rackspacecloud 
+# Cookbook Name:: rackspacecloud
 # Provider:: record
 #
 # Copyright:: 2013, Rackspace Hosting <ryan.walker@rackspace.com>
@@ -31,9 +31,11 @@ action :add do
     begin
       zone.records.create(:name => new_resource.record, :value => new_resource.value, :type => new_resource.type, :ttl => new_resource.ttl)
     rescue Fog::DNS::Rackspace::CallbackError => error
-      raise "Could not create DNS record: #{error}"
+      Chef::Log.warn "Could not create DNS record"
+      raise error # preserve unknown errors and pass them along
     rescue Fog::Rackspace::Errors::BadRequest => error
-      raise "There was a problem with the Create DNS Record request: #{error}"
+      Chef::Log.warn "There was a problem with the Create DNS Record request"
+      raise error # preserve unknown errors and pass them along
     end
     Chef::Log.info "#{new_resource.type} record created for #{new_resource.name}: #{new_resource.record} => #{new_resource.value}"
   end
@@ -58,9 +60,11 @@ action :update do
       begin
         record.save
       rescue Fog::DNS::Rackspace::CallbackError => error
-        raise "Could not update DNS record: #{error}"
+        Chef::Log.warn "Could not update DNS record"
+        raise error # preserve unknown errors and pass them along
       rescue Fog::Rackspace::Errors::BadRequest => error
-        raise "There was a problem updating the Create DNS record: #{error}"
+        Chef::Log.warn "There was a problem updating the Create DNS record"
+        raise error # preserve unknown errors and pass them along
       end
       Chef::Log.info "#{new_resource.type} record updated for #{new_resource.name}: #{new_resource.record} => #{new_resource.value}"
     end
@@ -69,9 +73,11 @@ action :update do
     begin
       zone.records.create(:name => new_resource.record, :value => new_resource.value, :type => new_resource.type, :ttl => new_resource.ttl)
     rescue Fog::DNS::Rackspace::CallbackError => error
-      raise "Could not create DNS record: #{error}"
+      Chef::Log.warn "Could not create DNS record"
+      raise error # preserve unknown errors and pass them along
     rescue Fog::Rackspace::Errors::BadRequest => error
-      raise "There was a problem with the Create DNS Record request: #{error}"
+      Chef::Log.warn "There was a problem with the Create DNS Record request"
+      raise error # preserve unknown errors and pass them along
     end
     Chef::Log.info "#{new_resource.type} record created for #{new_resource.name}: #{new_resource.record} => #{new_resource.value}"
   end
@@ -85,9 +91,11 @@ action :delete do
     begin
       record.destroy
     rescue Fog::DNS::Rackspace::CallbackError => error
-      raise "Could not delete DNS record: #{error}"
+      Chef::Log.warn "Could not delete DNS record"
+      raise error # preserve unknown errors and pass them along
     rescue Fog::Rackspace::Errors::BadRequest => error
-      raise "There was a problem deleting the DNS record: #{error}"
+      Chef::Log.warn "There was a problem deleting the DNS record"
+      raise error # preserve unknown errors and pass them along
     end
     Chef::Log.info("Record #{new_resource.record} deleted for domain #{new_resource.name}")
   else
@@ -118,7 +126,7 @@ def record_exists?(zone=nil)
   zone.records.all.each do |record|
     if record.name == new_resource.record
       return record.id
-    end 
+    end
   end
   return false
 end


### PR DESCRIPTION
- Ensure we raise the original error when we see something unexpected. It's been very difficult to troubleshoot when you can't see the underlying error. We're still logging the original error text. Apparently in Ruby 2.1+, this is fixed because `raise "foo"` automatically chains to the previous exception. But we're not on that everywhere, so this is a better solution.

- .kitchen.yml was super old. Updated to some modern platforms.