### PR TITLE
Install mime-types gem along with fog

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,12 @@ include_recipe 'xml::ruby' unless platform_family?("windows")
 
 chef_gem "fog" do
   version node[:rackspacecloud][:fog_version]
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
   action :install
+end
+
+chef_gem 'mime-types' do
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
 
 require 'fog'


### PR DESCRIPTION
Version 1.35.0 of fog-core dropped the explicit dependency on the
mime-types gem, but the storage drivers still need it.  Using the
rackspacecloud_file resource without it will raise an exception.  This
installs it alongside fog as well as fixes warnings about compile_time
installation on Chef 12.

  See: https://github.com/fog/fog-core/pull/170