### PR TITLE
Added rackspacecloud_dbaas_user resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Currently supported resources:
 * Rackspace Cloud Files ( rackspacecloud_file )
 * Rackspace Cloud Block storage ( rackspacecloud_cbs )
 * Rackspace Cloud Load Balancers ( rackspacecloud_lbaas)
+* Rackspace Cloud Database to manage users ( rackspacecloud_dbaas_user )
 
 Coming soon:
 
-* Rackspace Cloud Database
+* Rackspace Cloud Database (to manage instances)
 * Rackspace Cloud Servers
 
 Not Included:
@@ -77,6 +78,8 @@ The cookbook has several library modules which can be included where necessary:
 ```ruby
 Opscode::Rackspace
 Opscode::Rackspace::BlockStorage
+Opscode::Rackspace::Databases
+Opscode::Rackspace::LoadBalancers
 Opscode::Rackspace::DNS
 Opscode::Rackspace::Storage
 ```
@@ -213,6 +216,82 @@ end
 * ```rackspace_api_key```: The Rackspace API key. Can be retrieved from data bag or node attributes.
 * ```rackspace_region```: Region for load balancer (ORD, DFW, HKG, IAD, etc.)
 * ```action```: ```:add_node``` or ```:remove_node```. Default is ```:add_node```.
+
+
+rackspacecloud_dbaas_user
+-------------------
+
+Create/delete a user on/from a Database instance. Example:
+
+
+```ruby
+rackspacecloud_dbaas_user "MyUserName" do
+  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+  databases ["database1", "database2"]
+  password "thisissecret"
+  host "%"
+  rackspace_username "userName"
+  rackspace_api_key "apiKey"
+  rackspace_region "ORD"
+  action :create
+end
+```
+
+It will create the user `MyUserName` on the database instance `0a000b0f-00b0-000d-b00-0b0d0000c00a`. In addition it will grant access to this user on the database `database1` and `database2` from the host `%`.
+
+```ruby
+rackspacecloud_dbaas_user "MyUserName" do
+  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+  rackspace_username "userName"
+  rackspace_api_key "apiKey"
+  rackspace_region "ORD"
+  action :delete
+end
+```
+
+It will delete the user `MyUserName` from the database instance `0a000b0f-00b0-000d-b00-0b0d0000c00a`
+
+Grant or revoke access to a user to a Database.
+
+```ruby
+rackspacecloud_dbaas_user "MyUserName" do
+  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+  databases ["database1", "database2"]
+  host "%"
+  rackspace_username "userName"
+  rackspace_api_key "apiKey"
+  rackspace_region "ORD"
+  action :grant
+end
+```
+
+It will grant access to `MyUserName` on the database `database1` and `database2` from the host `%`. If the user doesn't exist, it will be created
+
+```ruby
+rackspacecloud_dbaas_user "MyUserName" do
+  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+  databases ["database1", "database2"]
+  host "%"
+  rackspace_username "userName"
+  rackspace_api_key "apiKey"
+  rackspace_region "ORD"
+  action :revoke
+end
+```
+
+It will revoke access to `MyUserName` from the database `database1` and `database2`
+
+### Attributes:
+* ```instance```: Id of the database instance to act on.
+* ```username```: Name of the user (default to resource name)
+* ```databases```: Array of databases to grant/revoke access to.
+* ```host```: Host source to grant access from (default to `%`)
+* ```password```: User's password
+* ```rackspace_username```: The Rackspace API username. Can be retrieved from data bag or node attributes.
+* ```rackspace_api_key```: The Rackspace API key. Can be retrieved from data bag or node attributes.
+* ```rackspace_region```: Region for load balancer (ORD, DFW, HKG, IAD, etc.)
+* ```action```: ```:create```,```:delete```, ```grant``` or ```revoke```. Default is ```:create```.
+
 
 
 rackspacecloud_cbs

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-default[:rackspacecloud][:fog_version] = "1.22.0"
+default[:rackspacecloud][:fog_version] = "1.37.0"
 default[:rackspacecloud][:rackspace_auth_url] = "identity.api.rackspacecloud.com"
 default[:rackspacecloud][:rackspace_auth_region] = "us"

--- a/libraries/databases.rb
+++ b/libraries/databases.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: rackspacecloud
+# Library:: Databases
+#
+# Copyright:: 2013, Rackspace Hosting <zack.feldstein@rackspace.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Opscode
+  module Rackspace
+    module Databases
+
+      include Opscode::Rackspace
+
+      def dbaas
+
+        @@dbaas ||= Fog::Rackspace::Databases.new(
+        {
+        	:rackspace_username  => new_resource.rackspace_username,
+        	:rackspace_api_key   => new_resource.rackspace_api_key,
+        	:rackspace_region    => new_resource.rackspace_region || :dfw,
+          :rackspace_auth_url  => new_resource.rackspace_auth_url || Fog::Rackspace::US_AUTH_ENDPOINT
+        })
+
+      end
+    end
+  end
+end

--- a/providers/dbaas_user.rb
+++ b/providers/dbaas_user.rb
@@ -1,0 +1,151 @@
+#
+# Cookbook Name:: rackspacecloud
+# Provider:: dbaas_user
+#
+# Copyright:: 2013, Rackspace Hosting <zack.feldstein@rackspace.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ostruct'
+include Opscode::Rackspace::Databases
+
+def whyrun_supported?
+  true
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::RackspacecloudDbaasUser.new(@new_resource.name)
+  user = get_user
+  unless user.nil? || user.empty?
+    @current_resource.exists = true
+    @current_resource.username = user['name']
+    @current_resource.databases = user['databases']
+    @current_resource.granted = @current_resource.databases == dbarray_to_dbhash(new_resource.databases) ? true : false
+    @current_resource.host = user['host']
+  else
+    @current_resource.exists = false
+    @current_resource
+  end
+end
+
+# Rackspace API expects an array of hashes for Databases
+def dbarray_to_dbhash(databases)
+  databases.map { |db| { 'name' => db } }
+end
+
+def get_user
+  begin
+    user = dbaas.list_users(new_resource.instance).body['users'].find do |dbuser|
+      dbuser['name'] == new_resource.username
+    end
+  rescue Fog::Rackspace::Databases::NotFound
+    raise 'Database instance ID specified does not exist, please create a database and provide a valid ID'
+  end
+  return user
+end
+
+def delete_user
+  dbaas.delete_user(new_resource.instance, new_resource.username)
+rescue Fog::Rackspace::Databases::NotFound
+  raise "User #{new_resource.username} not found on Database instance #{new_resource.instance}"
+else
+  Chef::Log.info "User #{new_resource.username} has been removed from Database instance #{new_resource.instance}"
+end
+
+def create_user
+  dbaas.create_user(
+    new_resource.instance,
+    new_resource.username,
+    new_resource.password,
+    databases: dbarray_to_dbhash(new_resource.databases), host: new_resource.host
+  )
+rescue Fog::Rackspace::Databases::NotFound
+  raise 'Database instance ID specified does not exist, please create a database and provide a valid ID'
+else
+  Chef::Log.info "User #{new_resource.username} has been created on Database instance #{new_resource.instance}"
+end
+
+def grant_user_access
+  # Fog requires an Obj in order to set the host
+  user = OpenStruct.new
+  user.name = new_resource.username
+  user.host = new_resource.host
+  dbaas.grant_user_access(new_resource.instance, user, *new_resource.databases)
+# If a database doesn't exist when granting permission the API will still return a success
+# so there is not much exceptions we can catch.
+# We could validate the DB exists first but it's probably out of scope for the Chef resource
+rescue Fog::Rackspace::Databases::NotFound
+  raise 'Database instance ID or user specified does not exist, please create a database and provide a valid ID'
+else
+  Chef::Log.info "User #{new_resource.username} has been granted access to the following databases: " +
+  new_resource.databases.join
+end
+
+def revoke_user_access
+  new_resource.databases.each do |db|
+    dbaas.revoke_user_access(new_resource.instance, new_resource.username, db)
+  end
+# If a database doesn't exist when granting permission the API will still return a success
+# so there is not much exceptions we can catch.
+# We could validate the DB exists first but it's probably out of scope for the Chef resource
+rescue Fog::Rackspace::Databases::NotFound
+  raise 'Database instance ID or user specified does not exist, please create a database and provide a valid ID'
+else
+  Chef::Log.info "User #{new_resource.username} has been denied access to the following databases: " +
+  new_resource.databases.join
+end
+
+def check_user_exists
+  @current_resource.exists
+end
+
+def check_grant_exists
+  @current_resource.granted && (@current_resource.host == new_resource.host)
+end
+
+action :create do
+  unless check_user_exists
+    converge_by("Adding user #{new_resource.username} to instance #{new_resource.instance}") do
+      create_user
+    end
+  end
+end
+
+action :delete do
+  if check_user_exists
+    converge_by("Removing user #{new_resource.username} from instance #{new_resource.instance}") do
+      delete_user
+    end
+  end
+end
+
+action :grant do
+  unless check_user_exists
+    converge_by("Adding user #{new_resource.username} to instance #{new_resource.instance}") do
+      create_user
+    end
+  end
+  unless check_grant_exists
+    converge_by("Giving user #{new_resource.username} access to databases: #{new_resource.databases.join}") do
+      grant_user_access
+    end
+  end
+end
+
+action :revoke do
+  if check_grant_exists
+    converge_by("Revoking user #{new_resource.username} access from databases: #{new_resource.databases.join}") do
+      revoke_user_access
+    end
+  end
+end

--- a/resources/dbaas_user.rb
+++ b/resources/dbaas_user.rb
@@ -29,4 +29,4 @@ attribute :instance, :kind_of => String, :required => true
 attribute :password, :kind_of => String
 attribute :host, :kind_of => String,  :default => "%"
 
-attr_accessor :exists, :granted
+attr_accessor :exists

--- a/resources/dbaas_user.rb
+++ b/resources/dbaas_user.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: rackspacecloud
+# Resource:: dbaas_user
+#
+# Copyright:: 2013, Rackspace Hosting <zack.feldstein@rackspace.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+actions :create, :delete, :grant, :revoke
+default_action :create
+
+attribute :rackspace_username, :kind_of => String, :required => true
+attribute :rackspace_api_key, :kind_of => String, :required => true
+attribute :rackspace_region, :kind_of => String, :default => "dfw"
+attribute :rackspace_auth_url, :kind_of => String
+attribute :username, :name_attribute => true,  :kind_of => String, :required => true
+attribute :databases, :kind_of => Array
+attribute :instance, :kind_of => String, :required => true
+attribute :password, :kind_of => String
+attribute :host, :kind_of => String,  :default => "%"
+
+attr_accessor :exists, :granted

--- a/test/fixtures/cookbooks/rackspacecloud_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/rackspacecloud_test/recipes/default.rb
@@ -135,3 +135,58 @@ rackspacecloud_cbs "test-cbs-03" do
   rackspace_region "ord"
   action :detach_and_delete
 end
+
+## Cloud Database ##
+# create a DB (TODO)
+#
+#rackspacecloud_dbaas 'test-db' do
+#  flavor '1GB Instance'
+#  size 10
+#  datastore_type 'MySQL'
+#  datastore_version '5.6'
+#  rackspace_username "foo"
+#  rackspace_api_key "nnnnnnnnnnn"
+#  rackspace_region "ord"
+#  action :create
+#end
+
+# All commented out for now as Fog doesn't support Mock for Dbaas
+# create a user
+#rackspacecloud_dbaas_user "MyUser" do
+#  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+#  databases ["database1", "database2"]
+#  password "secret"
+#  host "%"
+#  rackspace_username "userName"
+#  rackspace_api_key "apiKey"
+#  rackspace_region "ORD"
+#  action :create
+#end
+#
+#rackspacecloud_dbaas_user "MyUser" do
+#  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+#  databases ["database1", "database2"]
+#  host "%"
+#  rackspace_username "userName"
+#  rackspace_api_key "apiKey"
+#  rackspace_region "ORD"
+#  action :grant
+#end
+#
+#rackspacecloud_dbaas_user "MyUser" do
+#  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+#  databases ["database1", "database2"]
+#  host "%"
+#  rackspace_username "userName"
+#  rackspace_api_key "apiKey"
+#  rackspace_region "ORD"
+#  action :revoke
+#end
+#
+#rackspacecloud_dbaas_user "MyUser" do
+#  instance "0a000b0f-00b0-000d-b00-0b0d0000c00a"
+#  rackspace_username "userName"
+#  rackspace_api_key "apiKey"
+#  rackspace_region "ORD"
+#  action :delete
+#end


### PR DESCRIPTION
Add the `rackspacecloud_dbaas_user` resource. I don't have time to implement the `rackspacecloud_dbaas_instance` yet. Hopefully some of the foundation has been built with this PR making the last part of the dbaas resource easier to implement.

I had to bump Fog version to get the latest DBAAS methods. Which seems to break Mock for the rackspacecloud_dns.

In addition I've not been able to add tests for DBAAS due to the lack of Mock for fog rackspace database.

I'll look a bit more in what is the issue with the new version of Fog, then I'll look at submitting some Mock to Fog.